### PR TITLE
Fixed params

### DIFF
--- a/Magnet_To_Torrent2.py
+++ b/Magnet_To_Torrent2.py
@@ -37,6 +37,10 @@ def magnet2torrent(magnet, output_name = None):
   ses = lt.session()
   params = {
     'save_path': tempdir,
+    'duplicate_is_error': True,
+    'storage_mode': lt.storage_mode_t(2),
+    'paused': False,
+    'auto_managed': True,
     'duplicate_is_error': True
   }
   handle = lt.add_magnet_uri(ses, magnet, params)


### PR DESCRIPTION
I've fixed params for the call of  "add_magnet_uri" on line 46.
It was tested on ubuntu 11.04 with Python 2.7 and libtorrent 0.15.5-1.
