### PR TITLE
Use create_torrent(torrent_info) instead of manually copying propreties.

### DIFF
--- a/Magnet_To_Torrent2.py
+++ b/Magnet_To_Torrent2.py
@@ -54,9 +54,11 @@ def magnet2torrent(magnet, output_name = None):
       print "Cleanup dir " + tempdir
       shutil.rmtree(tempdir)
       return
+  ses.pause();
   print "done"
 
   torinfo = handle.get_torrent_info()
+  torfile = lt.create_torrent(torinfo)
 
   output = pt.abspath(torinfo.name() + ".torrent" )
 
@@ -66,22 +68,15 @@ def magnet2torrent(magnet, output_name = None):
     elif pt.isdir(pt.dirname(pt.abspath(output_name))) == True:
       output = pt.abspath(output_name)
   print 'saving torrent file here : ' + output + " ..."
-
-  fs = lt.file_storage()
-  for file in torinfo.files():
-    fs.add_file(file)
-  torfile = lt.create_torrent(fs)
-  torfile.set_comment(torinfo.comment())
-  torfile.set_creator(torinfo.creator())
-
+  
   torcontent = lt.bencode(torfile.generate())
   f = open(output, "wb")
   f.write(lt.bencode(torfile.generate()))
   f.close()
   print 'Saved! Cleaning up dir: ' + tempdir
+  ses.remove_torrent(handle);
   shutil.rmtree(tempdir)
   return output
- 
 
 def showHelp():
   print ""

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A command line tool that converts magnet links in to .torrent files.
 
 ## Requirements
 * python
-* python-libtorrent
+* python-libtorrent (libtorrent-rasterbar version 0.16 or later)
 
 ## How to Use
 `python Magnet_To_Torrent2.py <magnet link> [torrent file]`


### PR DESCRIPTION
Use create_torrent(torrent_info) to retrieve all torrent properties (including trackers) and not just files, comment and creator.
Requires libtorrent 0.16 (now around for a while).

Fixes bug https://github.com/danfolkes/Magnet2Torrent/issues/4 (this PR is inspired by the patch by @deice from this bug).

Because of the previous behavior, most torrents generated by this script where useless (not downloadable) because they did not included trackers from the magnet link and did not had the same info hash.
