### PR TITLE
used argparse for handling of cmdline args and updated example use

### DIFF
--- a/Magnet_To_Torrent2.py
+++ b/Magnet_To_Torrent2.py
@@ -28,6 +28,7 @@ import os.path as pt
 import sys
 import libtorrent as lt
 from time import sleep
+from argparse import ArgumentParser
 
 
 def magnet2torrent(magnet, output_name=None):
@@ -86,25 +87,14 @@ def magnet2torrent(magnet, output_name=None):
 
     return output
 
-
-def showHelp():
-    print("")
-    print("USAGE: " + pt.basename(sys.argv[0]) + " MAGNET [OUTPUT]")
-    print("  MAGNET\t- the magnet url")
-    print("  OUTPUT\t- the output torrent file name")
-    print("")
-
-
 def main():
-    if len(sys.argv) < 2:
-        showHelp()
-        sys.exit(0)
+    parser = ArgumentParser(description="A command line tool that converts magnet links in to .torrent files")
+    parser.add_argument('-m','--magnet', help='The magnet url', required=True)
+    parser.add_argument('-o','--output', help='The output torrent file name', required=True)
 
-    magnet = sys.argv[1]
-    output_name = None
-
-    if len(sys.argv) >= 3:
-        output_name = sys.argv[2]
+    args = vars(parser.parse_args())
+    magnet = args['magnet']
+    output_name = args['output']
 
     magnet2torrent(magnet, output_name)
 

--- a/Magnet_To_Torrent2.py
+++ b/Magnet_To_Torrent2.py
@@ -89,12 +89,56 @@ def magnet2torrent(magnet, output_name=None):
 
 def main():
     parser = ArgumentParser(description="A command line tool that converts magnet links in to .torrent files")
-    parser.add_argument('-m','--magnet', help='The magnet url', required=True)
-    parser.add_argument('-o','--output', help='The output torrent file name', required=True)
+    parser.add_argument('-m','--magnet', help='The magnet url')
+    parser.add_argument('-o','--output', help='The output torrent file name')
 
-    args = vars(parser.parse_args())
-    magnet = args['magnet']
-    output_name = args['output']
+    #
+    # This second parser is created to force the user to provide
+    # the 'output' arg if they provide the 'magnet' arg.
+    #
+    # The current version of argparse does not have support
+    # for conditionally required arguments. That is the reason
+    # for creating the second parser
+    #
+    # Side note: one should look into forking argparse and adding this
+    # feature.
+    #
+    conditionally_required_arg_parser = ArgumentParser(description="A command line tool that converts magnet links in to .torrent files")
+    conditionally_required_arg_parser.add_argument('-m','--magnet', help='The magnet url')
+    conditionally_required_arg_parser.add_argument('-o','--output', help='The output torrent file name', required=True)
+
+    magnet = None
+    output_name = None
+
+    #
+    # Attempting to retrieve args using the new method
+    #
+    args = vars(parser.parse_known_args()[0])
+    if args['magnet'] is not None:
+        magnet = args['magnet']
+        argsHack = vars(conditionally_required_arg_parser.parse_known_args()[0])
+        output_name = argsHack['output']
+    if args['output'] is not None and output_name is None:
+        output_name = args['output']
+        if magnet is None:
+            #
+            # This is a special case.
+            # This is when the user provides only the "output" args.
+            # We're forcing him to provide the 'magnet' args in the new method
+            #
+            print ('usage: {0} [-h] [-m MAGNET] -o OUTPUT'.format(sys.argv[0]))
+            print ('{0}: error: argument -m/--magnet is required'.format(sys.argv[0]))
+            sys.exit()
+    #
+    # Defaulting to the old of doing things
+    # 
+    if output_name is None and magnet is None:
+        if len(sys.argv) >= 2:
+            magnet = sys.argv[1]
+        if len(sys.argv) >= 3:
+            output_name = sys.argv[2]
+
+    print magnet, output_name
 
     magnet2torrent(magnet, output_name)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A command line tool that converts magnet links in to .torrent files.
 `python Magnet_To_Torrent2.py <magnet link> [torrent file]`
 
 ### Example
-`python Magnet_To_Torrent2.py "magnet:?xt=urn:btih:49fbd26322960d982da855c54e36df19ad3113b8&dn=ubuntu-12.04-desktop-i386.iso&tr=udp%3A%2F%2Ftracker.openbittorrent.com" ubunut12-04.iso`
+`python Magnet_To_Torrent2.py -m "magnet:?xt=urn:btih:49fbd26322960d982da855c54e36df19ad3113b8&dn=ubuntu-12.04-desktop-i386.iso&tr=udp%3A%2F%2Ftracker.openbittorrent.com" -o ubunut12-04.iso`
 
 ## Licenses
 All code is licensed under the [GPL version 3](http://www.gnu.org/licenses/gpl.html)


### PR DESCRIPTION
The current code uses `sys.argv` for retrieving the command line args. This means that showing error messages is up to the dev when the user does not provide the necessary args. This means that the devto have the `showHelp()` method. This update uses the `argparse` package and makes the code shorter.