### PR TITLE
Add quick fix to retain python 3 support

### DIFF
--- a/Magnet_To_Torrent2.py
+++ b/Magnet_To_Torrent2.py
@@ -22,6 +22,7 @@ Created on Apr 19, 2012
 
 '''
 
+from __future__ import print_function
 import shutil
 import tempfile
 import os.path as pt
@@ -137,7 +138,7 @@ def main():
         if len(sys.argv) >= 3:
             output_name = sys.argv[2]
 
-    print magnet, output_name
+    print(magnet, output_name)
 
     magnet2torrent(magnet, output_name)
 

--- a/Magnet_To_Torrent2.py
+++ b/Magnet_To_Torrent2.py
@@ -22,7 +22,6 @@ Created on Apr 19, 2012
 
 '''
 
-from __future__ import print_function
 import shutil
 import tempfile
 import os.path as pt
@@ -137,8 +136,6 @@ def main():
             magnet = sys.argv[1]
         if len(sys.argv) >= 3:
             output_name = sys.argv[2]
-
-    print(magnet, output_name)
 
     magnet2torrent(magnet, output_name)
 


### PR DESCRIPTION
The last pull request used a python 2 print statement.

All previous print statements doubled as print functions due to passing the singlton; whereas latest merge passed a pair, thus no longer can simply wrap parentheses to get the same affect in both versions.

importing the print function from future should fix this issue.